### PR TITLE
Add server and UI startup docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,32 @@
 # project-1-NeurogrammerT
+
+This repository hosts the Flame Haze Society Expense Reimbursement System. The codebase
+is split into two packages:
+
+- **flamehazesociety-server** – Node.js/TypeScript backend.
+- **flamehazesociety-ui** – React user interface.
+
+## Prerequisites
+- Node.js 12 or newer
+- npm (bundled with Node.js)
+
+## Getting Started
+
+### Server
+
+```bash
+cd flamehazesociety-server
+npm install
+npm start
+```
+
+### UI
+
+```bash
+cd flamehazesociety-ui
+npm install
+npm start
+```
+
+Ensure the server is running before interacting with the UI (typically available on
+http://localhost:3000/).


### PR DESCRIPTION
## Summary
- add instructions for running the `flamehazesociety-server` and `flamehazesociety-ui`
- mention required Node.js version and npm commands

## Testing
- `npm test` in `flamehazesociety-server` *(fails: Error: no test specified)*
- `npm test --silent` in `flamehazesociety-ui` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840734418a88332a76ae038cbd50a74