### PR TITLE
Fix typo in router messages

### DIFF
--- a/flamehazesociety-server/src/routers/reimbursement-router.ts
+++ b/flamehazesociety-server/src/routers/reimbursement-router.ts
@@ -171,7 +171,7 @@ reimbursementRouter.patch('/', authorizationMiddleware(['Finance Manager']), asy
         
         try {
             await updatedReimbursementService(updatedReimbursement)
-            res.send('You have succesfully updated this reimbursement')
+            res.send('You have successfully updated this reimbursement')
         } catch (e) {
             next(e)
         }
@@ -204,7 +204,7 @@ reimbursementRouter.delete('/', authorizationMiddleware(['Finance Manager']), as
         
         try {
             await deleteReimbursement(deletedReimbursement)  
-            res.send('You have succesfully deleted this reimbursement')
+            res.send('You have successfully deleted this reimbursement')
         } catch (e) {
             next(e)
         }

--- a/flamehazesociety-server/src/routers/user-router.ts
+++ b/flamehazesociety-server/src/routers/user-router.ts
@@ -114,7 +114,7 @@ userRouter.patch('/', async (req: Request, res: Response, next: NextFunction) =>
         try {
             await updateOneUser(updatedUser)
 
-            res.send('You have succesfully updated this user')
+            res.send('You have successfully updated this user')
         }
             
         catch (e) {
@@ -147,7 +147,7 @@ userRouter.delete('/', authorizationMiddleware(['Admin']), async (req: Request, 
         try {
             await deleteUser(deletedUser)
 
-            res.send('You have succesfully deleted this user')
+            res.send('You have successfully deleted this user')
 
         } catch (e) {
             next(e)


### PR DESCRIPTION
## Summary
- correct 'succesfully' to 'successfully' in user and reimbursement routers

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684072f6e33c8332a97103d400d07817